### PR TITLE
Dynamic Symbol Lookup

### DIFF
--- a/rclcpp/CMakeLists.txt
+++ b/rclcpp/CMakeLists.txt
@@ -9,6 +9,11 @@ include_directories(include)
 
 add_library(${PROJECT_NAME} SHARED src/rclcpp.cpp)
 ament_target_dependencies(${PROJECT_NAME} "rmw")
+if(APPLE)
+  # Since the rmw_* symbols are external, tell the linker on OS X to
+  # dynamically look them up at runtime.
+  set_target_properties(${PROJECT_NAME} PROPERTIES LINK_FLAGS "-undefined dynamic_lookup")
+endif()
 
 ament_export_dependencies(rmw)
 ament_export_include_directories(include)


### PR DESCRIPTION
This PR changes OS X to behave like Linux does by default, which is to build `librclcpp` even though not all symbols can be resolved at link time and hope that they are found when building an executable or library using `librclcpp`, i.e. the user's executable or library which is also linked against one of the rwm implementations.

I'm not aware of anyway to emulate this on Windows at the moment.
